### PR TITLE
Change cordova plugin id to match package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Plugin to integrate with Stetho a debug bridge for Android applications",
   "cordova": {
-    "id": "com.outsystems.mobile.stetho",
+    "id": "cordova-plugin-stetho-android",
     "platforms": [
       "android"
     ]

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,7 +7,7 @@
     <description>Plugin to integrate with Stetho a debug bridge for Android applications</description>
     <license>MIT License</license>
     <keywords>cordova, stetho, debug bridge, android</keywords>
-    <repo></repo>
+    <repo>https://github.com/HaidarZ/cordova-plugin-stetho-android.git</repo>
     <issue></issue>
 
     <js-module src="www/Stetho.js" name="Stetho">

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,7 +7,7 @@
     <description>Plugin to integrate with Stetho a debug bridge for Android applications</description>
     <license>MIT License</license>
     <keywords>cordova, stetho, debug bridge, android</keywords>
-    <repo>https://github.com/HaidarZ/cordova-plugin-stetho-android.git</repo>
+    <repo></repo>
     <issue></issue>
 
     <js-module src="www/Stetho.js" name="Stetho">

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-           id="com.outsystems.mobile.stetho"
+           id="cordova-plugin-stetho-android"
       version="0.0.1">
     <name>Stetho Plugin</name>
     <description>Plugin to integrate with Stetho a debug bridge for Android applications</description>


### PR DESCRIPTION
The plugin is causing issues when trying to reinstall. According the behavior below , we see that cordova is trying to fetch using the package id.

```
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/com.outsystems.mobile.stetho - Not found
npm ERR! 404 
npm ERR! 404  'com.outsystems.mobile.stetho@~0.0.1' is not in the npm registry.
npm ERR! 404 Your package name is not valid, because 
npm ERR! 404  1. name can only contain URL-friendly characters
npm ERR! 404  2. name can no longer contain special characters ("~'!()*")
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
```